### PR TITLE
added calcite bootstrap and side panel widget

### DIFF
--- a/index.html
+++ b/index.html
@@ -4,11 +4,13 @@
     <title>Map</title>
     <meta name="viewport" content="width=device-width, initial-scale=1">
     <link rel="stylesheet" href="https://js.arcgis.com/3.16/esri/css/esri.css">
+    <link rel="stylesheet" href="https://maxcdn.bootstrapcdn.com/bootstrap/3.3.6/css/bootstrap.min.css">
+    <link href="http://esri.github.io/calcite-bootstrap/assets/css/calcite-bootstrap-open.min.css" rel="stylesheet">
     <link rel="stylesheet" href="styles/main.css">
   </head>
   <body>
     <div id="map">
-      <div id="time"></div>
+      <div id="sidePanel"></div>
     </div>
     <script>
       window.dojoConfig = {

--- a/package.json
+++ b/package.json
@@ -9,6 +9,7 @@
     "replace": "^0.3.0",
     "rollup": "^0.25.8",
     "rollup-plugin-babel": "^2.4.0",
+    "rollup-plugin-string": "^1.0.1",
     "semistandard": "^7.0.5",
     "uglify-js": "^1.3.5"
   },

--- a/rollup-config.js
+++ b/rollup-config.js
@@ -1,5 +1,6 @@
 import { rollup } from 'rollup';
 import babel from 'rollup-plugin-babel';
+import string from 'rollup-plugin-string';
 
 export default {
   entry: 'src/main.js',
@@ -9,7 +10,11 @@ export default {
     // compile future ES 2015 to runnable ES 5
     babel({
       runtimeHelpers: true,
-      exclude: 'node_modules/**' // don't compile things in node_modules
+      exclude: 'src/templates/**' // don't compile templates
+    }),
+    // load templates from files
+    string({
+      extensions: ['.html']
     })
   ]
 };

--- a/scripts/postbuild.js
+++ b/scripts/postbuild.js
@@ -13,5 +13,5 @@ replace({
   replacement: '',
   paths: ['dist/bundle.js'],
   recursive: true,
-  silent: false,
+  silent: false
 });

--- a/src/SidePanel.css
+++ b/src/SidePanel.css
@@ -1,0 +1,6 @@
+.side-panel {
+  position: absolute;
+  top: 20px;
+  right: 20px;
+  z-index: 1;
+}

--- a/src/SidePanel.js
+++ b/src/SidePanel.js
@@ -1,0 +1,26 @@
+import declare from 'dojo/_base/declare';
+import _WidgetBase from 'dijit/_WidgetBase';
+import _TemplatedMixin from 'dijit/_TemplatedMixin';
+import _Container from 'dijit/_Container';
+// NOTE: we're using Rollup's string plugin to load template
+// this will be inlined into the build output
+import template from './templates/SidePanel.html';
+import strings from 'dojo/i18n!./nls/strings';
+import TimeWidget from './TimeWidget';
+
+export default declare([_WidgetBase, _Container, _TemplatedMixin], {
+
+  baseClass: 'side-panel',
+  nls: strings,
+  templateString: template,
+
+  postCreate () {
+    this.inherited(arguments);
+
+    // side panel
+    this.titleNode.innerHTML = strings.sidePanelTitle;
+
+    // add time widget
+    this.addChild(new TimeWidget());
+  }
+});

--- a/src/TimeWidget.css
+++ b/src/TimeWidget.css
@@ -1,9 +1,0 @@
-.time-widget {
-  position: absolute;
-  top: 10px;
-  right: 10px;
-  z-index: 30;
-  background: #fff;
-  border: 1px solid;
-  padding: 10px;
-}

--- a/src/TimeWidget.js
+++ b/src/TimeWidget.js
@@ -9,8 +9,7 @@ export default declare([_WidgetBase, _TemplatedMixin], {
 
   baseClass: 'time-widget',
   nls: strings,
-  // using an inline template here, but this probably
-  // could have been brought in via dojo/text plugin
+  // using an inline template here
   templateString: `<div>
     ${strings.timeMessage} <span data-dojo-attach-point="timeNode"></span>
   </div>`,

--- a/src/main.js
+++ b/src/main.js
@@ -1,5 +1,5 @@
 import mapService from './mapService';
-import TimeWidget from './TimeWidget';
+import SidePanel from './SidePanel';
 
 mapService.createMap('map', {
   center: [-118, 34.5],
@@ -7,5 +7,5 @@ mapService.createMap('map', {
   basemap: 'topo'
 });
 
-const timeWidget = new TimeWidget();
-timeWidget.placeAt('time');
+const sidePanel = new SidePanel();
+sidePanel.placeAt('sidePanel');

--- a/src/nls/strings.js
+++ b/src/nls/strings.js
@@ -1,6 +1,7 @@
 /* global define */
 define({
   root: {
+    sidePanelTitle: 'Side Panel',
     timeMessage: 'The time is '
   }
 });

--- a/src/templates/SidePanel.html
+++ b/src/templates/SidePanel.html
@@ -1,0 +1,7 @@
+<div class="panel panel-default">
+  <div class="panel-heading">
+    <h3 class="panel-title" data-dojo-attach-point="titleNode"></h3>
+  </div>
+  <div class="panel-body" data-dojo-attach-point="containerNode">
+  </div>
+</div>

--- a/styles/main.css
+++ b/styles/main.css
@@ -1,4 +1,4 @@
-@import url('../src/TimeWidget.css');
+@import url('../src/SidePanel.css');
 
 html, body, #map {
   width: 100%;


### PR DESCRIPTION
only using CSS (no JS) and loading from CDN
added Rollup's string plugin to load and inline HTML templates
