### PR TITLE
only include the bootstrap components used by the app

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,11 @@
 All notable changes to this project will be documented in this file.
 This project adheres to [Semantic Versioning](http://semver.org/).
 
+## v0.1.4
+
+### Changed
+* only include the bootstrap components used by the app
+
 ## v0.1.3
 
 ### Added

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -69,12 +69,16 @@ gulp.task('scripts', ['rollup'], function () {
     .pipe(gulp.dest('dist/app'));
 });
 
-// copy vendor scripts
+// concatenate vendor scripts and minify (as needed)
 gulp.task('scripts:vendor', function () {
   return gulp.src([
     './node_modules/jquery/dist/jquery.min.js',
-    './node_modules/bootstrap-sass/assets/javascripts/bootstrap.min.js'
+    // NOTE: include other bootstrap components here as needed
+    './node_modules/bootstrap-sass/assets/javascripts/bootstrap/transition.js',
+    './node_modules/bootstrap-sass/assets/javascripts/bootstrap/collapse.js'
   ])
+  // minify unminified source (only)
+  .pipe($.if('!*.min.js', $.uglify()))
   .pipe($.concat('vendor.js'))
   .pipe(gulp.dest('dist/vendor'));
 });

--- a/package.json
+++ b/package.json
@@ -13,6 +13,7 @@
     "gulp-concat": "^2.6.0",
     "gulp-debug": "^2.1.2",
     "gulp-gh-pages": "^0.5.4",
+    "gulp-if": "^2.0.0",
     "gulp-load-plugins": "^1.2.1",
     "gulp-rename": "^1.2.2",
     "gulp-replace": "^0.5.4",

--- a/src/styles/_appstrap.scss
+++ b/src/styles/_appstrap.scss
@@ -1,0 +1,56 @@
+// NOTE: copied from:
+// ./node_modules/bootstrap-sass/assets/stylesheets/_bootstrap.scss
+// and commented out unused modules
+
+// TODO: uncomment as needed when adding modules
+
+// Core variables and mixins
+@import "bootstrap/variables";
+@import "bootstrap/mixins";
+
+// Reset and dependencies
+@import "bootstrap/normalize";
+@import "bootstrap/print";
+@import "bootstrap/glyphicons";
+
+// Core CSS
+@import "bootstrap/scaffolding";
+@import "bootstrap/type";
+@import "bootstrap/code";
+@import "bootstrap/grid";
+@import "bootstrap/tables";
+@import "bootstrap/forms";
+@import "bootstrap/buttons";
+
+// Components
+@import "bootstrap/component-animations";
+@import "bootstrap/dropdowns";
+// @import "bootstrap/button-groups";
+// @import "bootstrap/input-groups";
+// @import "bootstrap/navs";
+// @import "bootstrap/navbar";
+// @import "bootstrap/breadcrumbs";
+// @import "bootstrap/pagination";
+// @import "bootstrap/pager";
+// @import "bootstrap/labels";
+// @import "bootstrap/badges";
+// @import "bootstrap/jumbotron";
+// @import "bootstrap/thumbnails";
+// @import "bootstrap/alerts";
+// @import "bootstrap/progress-bars";
+// @import "bootstrap/media";
+// @import "bootstrap/list-group";
+@import "bootstrap/panels";
+// @import "bootstrap/responsive-embed";
+// @import "bootstrap/wells";
+// @import "bootstrap/close";
+
+// Components w/ JavaScript
+// @import "bootstrap/modals";
+// @import "bootstrap/tooltip";
+// @import "bootstrap/popovers";
+// @import "bootstrap/carousel";
+
+// Utility classes
+// @import "bootstrap/utilities";
+// @import "bootstrap/responsive-utilities";

--- a/src/styles/main.scss
+++ b/src/styles/main.scss
@@ -2,7 +2,9 @@
 @import 'calcite-bootstrap';
 /* set the output folder for fonts */
 $icon-font-path: './fonts/';
-@import 'bootstrap';
+
+// contains only the bootstrap modules used in this app
+@import 'appstrap';
 
 /* app layout */
 html, body, #app, .map-container {


### PR DESCRIPTION
comment out all Sass imports not used by the app
only concatenate (and minify) scripts for components used by the app

File sizes (according to gulp-size) before:

```
[23:30:27] build styles\main.css 166.33 kB (gzipped)
[23:30:27] build vendor\vendor.js 39.05 kB (gzipped)
[23:30:27] build all files 325.95 kB (gzipped)
```

And after:

```
[23:33:33] build styles\main.css 114.07 kB (gzipped)
[23:33:34] build vendor\vendor.js 31.05 kB (gzipped)
[23:33:34] build all files 265.69 kB (gzipped)
```

resolves #20
