### PR TITLE
importing capitalize() from ES2015 build of lodash

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,11 @@
 All notable changes to this project will be documented in this file.
 This project adheres to [Semantic Versioning](http://semver.org/).
 
+## Unreleased
+
+### Added
+* importing capitalize() from ES2015 build of lodash
+
 ## v0.1.5
 
 ### Changed

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -119,7 +119,7 @@ gulp.task('html', function () {
 
 // build, copy to dist, and size'r up
 gulp.task('build', ['lint', 'fonts', 'scripts:vendor', 'nls', 'scripts', 'styles', 'html'], function () {
-  return gulp.src('dist/**/*').pipe($.size({title: 'build', gzip: true}));
+  return gulp.src('dist/**/*').pipe($.size({title: 'build', gzip: true, showFiles: true}));
 });
 
 // serve up the built application

--- a/package.json
+++ b/package.json
@@ -3,7 +3,9 @@
   "version": "0.1.5",
   "description": "Example application using Rollup to bundle local ES2015 modules that use CDN hosted modules from the ArcGIS API for JavaScript",
   "main": "src/main.js",
-  "dependencies": {},
+  "dependencies": {
+    "lodash-es": "^4.11.1"
+  },
   "devDependencies": {
     "babel-preset-es2015-rollup": "^1.1.1",
     "browser-sync": "^2.12.3",

--- a/src/app/utils.js
+++ b/src/app/utils.js
@@ -1,3 +1,9 @@
+// with ES2015 dependencies you have the option of
+// importing their functions directly and
+// Rollup will include the function and others it references
+// in the bundled output along with the application code
+import capitalize from '../../node_modules/lodash-es/capitalize';
+
 // place stateless utility functions in this file
 // they can be imported into other files as needed
 export function formatTitle (title) {
@@ -7,5 +13,8 @@ export function formatTitle (title) {
   }
 
   // replace dashes and underscores w/ spaces
-  return title.replace(/-|_/g, ' ');
+  return title.replace(/-|_/g, ' ').split(' ').map(word => {
+    // and capitalize each word
+    return capitalize(word);
+  }).join(' ');
 }


### PR DESCRIPTION
Demonstrate how to include ES2015 code in the bundle. Thanks to tree shaking, only the imported `capitalize()` function and the functions it calls (and unfortunately [any code that Rollup can't determine whether or not it is needed](https://github.com/rollup/rollup/issues/45#issuecomment-168127982)) is brought into the bundle.

The purpose of this is illustrate the tradeoffs involved when bundling vendor code w/ application code. On the one hand, it's included in the single download, and you have direct access to the vendor functions while debugging. On the other hand the bundle is now a bit more cluttered and can be harder to debug.

This works OK, but in this case, b/c we're already concatenating and minifying vendor code into vendor.js, I'm not sure it benefits this application. I'm pretty sure you could get a full custom build of lodash into vendor.js for about the same size (or less since I'm not doing a great job w/ source maps) and number of requests as result from this PR.

There are plenty of opportunities to tweak build configurations (maybe a dev build focused on debugging, or better use of sourcemaps), so I think it's worth merging this experiment as is even though in a real app I'll probably just include (a custom build of?) lodash in vendor.js.
