### PR TITLE
rollup versions

### DIFF
--- a/package.json
+++ b/package.json
@@ -24,10 +24,10 @@
     "gulp-sourcemaps": "^1.6.0",
     "gulp-uglify": "^1.5.3",
     "jquery": "^2.2.3",
-    "rollup": "^0.25.8",
+    "rollup": "^0.34.2",
     "rollup-plugin-babel": "^2.4.0",
     "rollup-plugin-string": "^1.0.1",
-    "rollup-plugin-uglify": "^0.3.1",
+    "rollup-plugin-uglify": "^1.0.1",
     "semistandard": "^7.0.5"
   },
   "scripts": {


### PR DESCRIPTION
bumping `rollup` and `rollup-plugin-uglify` to more recent versions to solve the "node 4 and 5" errors from #32.

Not sure if this solves the "Node 6" issue from #32 though ... haven't had a chance to test yet.
