### PR TITLE
updated rollup, rollup-babel plugin, and other packages to latest

### DIFF
--- a/.babelrc
+++ b/.babelrc
@@ -1,3 +1,11 @@
 {
-  "presets": [ "es2015-rollup" ]
+  "presets": [
+    [
+      "es2015",
+      {
+        "modules": false
+      }
+    ]
+  ],
+  "plugins": ["external-helpers"]
 }

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -39,7 +39,7 @@ gulp.task('scripts:app', function () {
       }),
       // load templates from files
       rollupString({
-        extensions: ['.html']
+        include: ['**/*.html']
       }),
       // minify output
       rollupUglify()

--- a/package.json
+++ b/package.json
@@ -7,7 +7,8 @@
     "lodash-es": "^4.11.1"
   },
   "devDependencies": {
-    "babel-preset-es2015-rollup": "^1.1.1",
+    "babel-plugin-external-helpers": "^6.8.0",
+    "babel-preset-es2015": "^6.16.0",
     "browser-sync": "^2.12.3",
     "calcite-bootstrap": "^0.3.2",
     "del": "^2.2.0",
@@ -19,16 +20,16 @@
     "gulp-load-plugins": "^1.2.1",
     "gulp-rename": "^1.2.2",
     "gulp-sass": "^2.2.0",
-    "gulp-semistandard": "^0.2.2",
+    "gulp-semistandard": "^1.0.0",
     "gulp-size": "^2.1.0",
-    "gulp-sourcemaps": "^1.6.0",
-    "gulp-uglify": "^1.5.3",
+    "gulp-sourcemaps": "^2.1.1",
+    "gulp-uglify": "^2.0.0",
     "jquery": "^2.2.3",
-    "rollup": "^0.34.2",
-    "rollup-plugin-babel": "^2.4.0",
-    "rollup-plugin-string": "^1.0.1",
+    "rollup": "^0.36.3",
+    "rollup-plugin-babel": "^2.6.1",
+    "rollup-plugin-string": "^2.0.2",
     "rollup-plugin-uglify": "^1.0.1",
-    "semistandard": "^7.0.5"
+    "semistandard": "^9.1.0"
   },
   "scripts": {
     "test": "gulp test",


### PR DESCRIPTION
switching babel preset from `es2015-rollup` to `es2015`, per comment [here](https://github.com/rollup/babel-preset-es2015-rollup/issues/11#issuecomment-241822404) and instructions [here](https://github.com/rollup/rollup-plugin-babel#configuring-babel). 

According to [those instructions](https://github.com/rollup/rollup-plugin-babel#configuring-babel) this is only for Babel v6, but it's working better for me on babel v3.x, so I'm fairly certain it should work fine generally, but would like others to test on other environments if possible.

Fixes issue #35 for me. 
